### PR TITLE
Add dependabot security updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The purpose of this tool is to help enable GitHub Advanced Security (GHAS) across multiple repositories in an automated way. There will be times when you need the ability to enable Code Scanning (CodeQL), Secret Scanning and/or Dependabot across various repositories, and you don't want to click buttons manually or drop a GitHub Workflow for CodeQL into every repository. Doing this is manual and painstaking. The purpose of this utility is to help automate these manual tasks.
+The purpose of this tool is to help enable GitHub Advanced Security (GHAS) across multiple repositories in an automated way. There will be times when you need the ability to enable Code Scanning (CodeQL), Secret Scanning, Dependabot Alerts, and/or Dependabot Security Updates across various repositories, and you don't want to click buttons manually or drop a GitHub Workflow for CodeQL into every repository. Doing this is manual and painstaking. The purpose of this utility is to help automate these manual tasks.
 
 ## Context
 
@@ -16,7 +16,7 @@ There are two main actions this tool does:
 
 **Part One:**
 
-Goes and collects repositories that will have Code Scanning(CodeQL)/Secret Scanning/Dependabot enabled. There are three main ways these repositories are collected.
+Goes and collects repositories that will have Code Scanning(CodeQL)/Secret Scanning/Dependabot Alerts/Dependabot Security Updates enabled. There are three main ways these repositories are collected.
 
 - Collect the repositories where the primary language matches a specific value. For example, if you provide JavaScript, all repositories will be collected where the primary language is, Javascript.
 - Collect the repositories to which a user has administrative access, or a GitHub App has access.
@@ -26,7 +26,7 @@ If you select option 1, the script will return all repositories in the language 
 
 **Part Two:**
 
-Loops over the repositories found within the `repos.json` file and enables Code Scanning(CodeQL)/Secret Scanning/Dependabot.
+Loops over the repositories found within the `repos.json` file and enables Code Scanning(CodeQL)/Secret Scanning/Dependabot Alerts/Dependabot Security Updates.
 
 If you pick Code Scanning:
 
@@ -36,9 +36,13 @@ If you pick Secret Scanning:
 
 - Loops over the repositories found within the `repos.json` file. Secret Scanning is then enabled on these repositories.
 
-If you pick Dependabot:
+If you pick Dependabot Alerts:
 
-- Loops over the repositories found within the `repos.json` file. Dependabot is then enabled on these repositories.
+- Loops over the repositories found within the `repos.json` file. Dependabot Alerts is then enabled on these repositories.
+
+If you pick Dependabot Security Updates:
+
+- Loops over the repositories found within the `repos.json` file. Dependabot Security Updates is then enabled on these repositories.
 
 ## Prerequisite
 
@@ -78,7 +82,7 @@ mv .env.sample .env
 
 7. Update the `LANGUAGE_TO_CHECK` value found within the `.env`. Remove the `XXXX` and replace that with the language you would like to use as a filter when collecting repositories. **Note**: Please make sure these are lowercase values, such as: `javascript`, `python`, `go`, `ruby`, etc.
 
-8. Decide what you want to enable. Update the `ENABLE_ON` value to deicde what you want to enable on the repositories found within the `repos.json`. This can be one or multiple values. If you are enabling just code scanning (CodeQL) you will need to set `ENABLE_ON=codescanning`, if you are enabling everything, you will need to set `ENABLE_ON=codescanning,secretscanning,dependabot`. You can pick one, two or three. The format is a comma seperated list.
+8. Decide what you want to enable. Update the `ENABLE_ON` value to deicde what you want to enable on the repositories found within the `repos.json`. This can be one or multiple values. If you are enabling just code scanning (CodeQL) you will need to set `ENABLE_ON=codescanning`, if you are enabling everything, you will need to set `ENABLE_ON=codescanning,secretscanning,dependabot,dependabotupdates`. You can pick one, two or three. The format is a comma seperated list.
 
 9. **OPTIONAL**: Update the `CREATE_ISSUE` value to `true/false` depending on if you would like to create an issue explaining purpose of the PR. We recommend this, as it will help explain why the PR was create; and give some context. However, this is optional. The text which is in the issue can be modified and found here: `./src/utils/text/`.
 
@@ -126,20 +130,22 @@ Create a file called `repos.json` within the `./bin/` directory. This file needs
 [
   {
     "enableDependabot": "boolean",
+    "enableDependabotUpdates": "boolean",
     "enableSecretScanning": "boolean",
+    "enableCodeScanning": "boolean",
     "createIssue": "boolean",
     "repo": "string <org/repo>",
   }
 ]
 ```
 
-As you can see, the object takes four keys: `repo`, `enableSecretScanning`, `createIssue` and `enableDependabot`. Set `repo` to the name of the repository name where you would like to run this script on. Set `enableDependabot` to `true` if you would also like to enable `Dependabot` on that repo; set it to `false` if you do not want to enable `Dependabot`. The same foes for `enableDependabot`. Finally set `createIssue` to `true` if you would like to create an issue on the repository with the text found in the `./src/utils/text/issueText.ts` directory.
+As you can see, the object takes six keys: `repo`, `enableDependabot`, `enableDependabotUpdates`, `enableSecretScanning`, `enableCodeScanning`, and `enableCodeScanning`. Set `repo` to the name of the repository name where you would like to run this script on. Set `enableDependabot` to `true` if you would also like to enable Dependabot Alerts on that repo; set it to `false` if you do not want to enable Dependabot Alerts. The same goes for `enableDependabotUpdates` for Dependabot Security Updates, `enableSecretScanning` for Secret Scanning, and `enableCodeScanning` for Code Scanning (CodeQL). Finally set `createIssue` to `true` if you would like to create an issue on the repository with the text found in the `./src/utils/text/issueText.ts` directory.
 
 **NOTE:** The account that generated the PAT needs to have `write` access or higher over any repository that you include within the `repos` key.
 
 ### Step Two
 
-Run the script which enables Code Scanning (and/or Dependabot/Secret Scanning) on your repository by running:
+Run the script which enables Code Scanning (and/or Dependabot Alerts/Dependabot Security Updates/Secret Scanning) on your repository by running:
 
 ```bash
 yarn run start // or npm run start

--- a/bin/repos.json
+++ b/bin/repos.json
@@ -4,6 +4,7 @@
     "repos": [
       {
         "enableDependabot": false,
+        "enableDependabotFixes": false,
         "enableSecretScanning": false,
         "enableCodeScanning": true,
         "createIssue": true,

--- a/bin/repos.json
+++ b/bin/repos.json
@@ -4,7 +4,7 @@
     "repos": [
       {
         "enableDependabot": false,
-        "enableDependabotFixes": false,
+        "enableDependabotUpdates": false,
         "enableSecretScanning": false,
         "enableCodeScanning": true,
         "createIssue": true,

--- a/src/utils/enableDependabotAlerts.ts
+++ b/src/utils/enableDependabotAlerts.ts
@@ -47,10 +47,10 @@ export const enableDependabotAlerts = async (
     octokit
   )) as response;
 
-  inform(`Is Dependabot enabled already for ${repo}? : ${message}`);
+  inform(`Is Dependabot Alerts enabled already for ${repo}? : ${message}`);
 
   if (status === 204) {
-    return { status, message: "Repository already had Dependabot Enabled" };
+    return { status, message: "Repository already had Dependabot Alerts Enabled" };
   }
 
   try {
@@ -62,7 +62,7 @@ export const enableDependabotAlerts = async (
     return { status, message: "Enabled" } as response;
   } catch (err) {
     error(
-      `Problem enabling Dependabot on the following repository: ${requestParams.repo}. The error was: ${err}`
+      `Problem enabling Dependabot Alerts on the following repository: ${requestParams.repo}. The error was: ${err}`
     );
     throw err;
   }

--- a/src/utils/enableDependabotAlerts.ts
+++ b/src/utils/enableDependabotAlerts.ts
@@ -50,7 +50,10 @@ export const enableDependabotAlerts = async (
   inform(`Is Dependabot Alerts enabled already for ${repo}? : ${message}`);
 
   if (status === 204) {
-    return { status, message: "Repository already had Dependabot Alerts Enabled" };
+    return {
+      status,
+      message: "Repository already had Dependabot Alerts Enabled",
+    };
   }
 
   try {

--- a/src/utils/enableDependabotUpdates.ts
+++ b/src/utils/enableDependabotUpdates.ts
@@ -29,7 +29,9 @@ export const enableDependabotFixes = async (
       "PUT /repos/{owner}/{repo}/automated-security-fixes",
       requestParams
     )) as createVulnerabilityUpdatesResponse;
-    inform(`Enabled Dependabot Security Updates for ${repo}. Status: ${status}`);
+    inform(
+      `Enabled Dependabot Security Updates for ${repo}. Status: ${status}`
+    );
     return { status, message: "Enabled" } as response;
   } catch (err) {
     error(

--- a/src/utils/enableDependabotUpdates.ts
+++ b/src/utils/enableDependabotUpdates.ts
@@ -1,0 +1,40 @@
+import { inform, error } from "./globals";
+
+import { Octokit } from "./octokitTypes";
+
+import {
+  createVulnerabilityUpdatesParameters,
+  createVulnerabilityUpdatesResponse,
+} from "./octokitTypes";
+
+import { response } from "../../types/common";
+
+// currently there is no api for getting dependabot security updates status
+
+export const enableDependabotUpdates = async (
+  owner: string,
+  repo: string,
+  octokit: Octokit
+): Promise<response> => {
+  const requestParams = {
+    owner,
+    repo,
+    mediaType: {
+      previews: ["dorian"],
+    },
+  } as createVulnerabilityUpdatesParameters;
+
+  try {
+    const { status } = (await octokit.request(
+      "PUT /repos/{owner}/{repo}/automated-security-fixes",
+      requestParams
+    )) as createVulnerabilityUpdatesResponse;
+    inform(`Enabled Dependabot Security Updates for ${repo}. Status: ${status}`);
+    return { status, message: "Enabled" } as response;
+  } catch (err) {
+    error(
+      `Problem enabling Dependabot Security Updates on the following repository: ${requestParams.repo}. The error was: ${err}`
+    );
+    throw err;
+  }
+};

--- a/src/utils/enableDependabotUpdates.ts
+++ b/src/utils/enableDependabotUpdates.ts
@@ -11,7 +11,7 @@ import { response } from "../../types/common";
 
 // currently there is no api for getting dependabot security updates status
 
-export const enableDependabotUpdates = async (
+export const enableDependabotFixes = async (
   owner: string,
   repo: string,
   octokit: Octokit

--- a/src/utils/octokitTypes.ts
+++ b/src/utils/octokitTypes.ts
@@ -69,6 +69,11 @@ export type createVulnerabilityAlertsParameters =
 export type createVulnerabilityAlertsResponse =
   Endpoints["PUT /repos/{owner}/{repo}/vulnerability-alerts"]["response"];
 
+export type createVulnerabilityUpdatesParameters =
+  Endpoints["PUT /repos/{owner}/{repo}/automated-security-fixes"]["parameters"];
+export type createVulnerabilityUpdatesResponse =
+  Endpoints["PUT /repos/{owner}/{repo}/automated-security-fixes"]["response"];
+
 export type putFileInPathParameters =
   Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["parameters"];
 export type putFileInPathResponse =

--- a/src/utils/paginateQuery.ts
+++ b/src/utils/paginateQuery.ts
@@ -87,6 +87,7 @@ const getRepositoryInOrganizationPaginate = async (
     results.forEach((element) => {
       return paginatedData.push({
         enableDependabot: enable.includes("dependabot") as boolean,
+        enableDependabotFixes: enable.includes("dependabotfixes") as boolean,
         enableSecretScanning: enable.includes("secretscanning") as boolean,
         enableCodeScanning: enable.includes("codescanning") as boolean,
         createIssue:

--- a/src/utils/paginateQuery.ts
+++ b/src/utils/paginateQuery.ts
@@ -87,7 +87,7 @@ const getRepositoryInOrganizationPaginate = async (
     results.forEach((element) => {
       return paginatedData.push({
         enableDependabot: enable.includes("dependabot") as boolean,
-        enableDependabotFixes: enable.includes("dependabotfixes") as boolean,
+        enableDependabotUpdates: enable.includes("dependabotupdates") as boolean,
         enableSecretScanning: enable.includes("secretscanning") as boolean,
         enableCodeScanning: enable.includes("codescanning") as boolean,
         createIssue:

--- a/src/utils/paginateQuery.ts
+++ b/src/utils/paginateQuery.ts
@@ -87,7 +87,9 @@ const getRepositoryInOrganizationPaginate = async (
     results.forEach((element) => {
       return paginatedData.push({
         enableDependabot: enable.includes("dependabot") as boolean,
-        enableDependabotUpdates: enable.includes("dependabotupdates") as boolean,
+        enableDependabotUpdates: enable.includes(
+          "dependabotupdates"
+        ) as boolean,
         enableSecretScanning: enable.includes("secretscanning") as boolean,
         enableCodeScanning: enable.includes("codescanning") as boolean,
         createIssue:

--- a/src/utils/worker.ts
+++ b/src/utils/worker.ts
@@ -10,6 +10,7 @@ import { restClient as octokit } from "./clients";
 import { commitFileMac } from "./commitFile.js";
 import { enableGHAS } from "./enableGHAS.js";
 import { enableDependabotAlerts } from "./enableDependabotAlerts";
+import { enableDependabotUpdates } from "./enableDependabotUpdates";
 import { enableIssueCreation } from "./enableIssueCreation";
 import repos from "../../bin/repos.json";
 
@@ -36,6 +37,7 @@ export const worker = async (): Promise<unknown> => {
       const {
         repo: repoName,
         enableDependabot,
+        enableDependabotFixes,
         enableSecretScanning,
         createIssue,
         enableCodeScanning,
@@ -51,6 +53,11 @@ export const worker = async (): Promise<unknown> => {
       // If they want to enable Dependabot, and they are NOT on GHES (as that currently isn't GA yet), enable Dependabot
       enableDependabot && process.env.GHES != "true"
         ? await enableDependabotAlerts(owner, repo, client)
+        : null;
+
+      // If they want to enable Dependabot Security Updates, and they are NOT on GHES (as that currently isn't GA yet), enable Dependabot Security Updates
+      enableDependabotFixes && process.env.GHES != "true"
+        ? await enableDependabotUpdates(owner, repo, client)
         : null;
 
       // Kick off the process for enabling Secret Scanning

--- a/src/utils/worker.ts
+++ b/src/utils/worker.ts
@@ -10,7 +10,7 @@ import { restClient as octokit } from "./clients";
 import { commitFileMac } from "./commitFile.js";
 import { enableGHAS } from "./enableGHAS.js";
 import { enableDependabotAlerts } from "./enableDependabotAlerts";
-import { enableDependabotUpdates } from "./enableDependabotUpdates";
+import { enableDependabotFixes } from "./enableDependabotUpdates";
 import { enableIssueCreation } from "./enableIssueCreation";
 import repos from "../../bin/repos.json";
 
@@ -37,7 +37,7 @@ export const worker = async (): Promise<unknown> => {
       const {
         repo: repoName,
         enableDependabot,
-        enableDependabotFixes,
+        enableDependabotUpdates,
         enableSecretScanning,
         createIssue,
         enableCodeScanning,
@@ -56,8 +56,8 @@ export const worker = async (): Promise<unknown> => {
         : null;
 
       // If they want to enable Dependabot Security Updates, and they are NOT on GHES (as that currently isn't GA yet), enable Dependabot Security Updates
-      enableDependabotFixes && process.env.GHES != "true"
-        ? await enableDependabotUpdates(owner, repo, client)
+      enableDependabotUpdates && process.env.GHES != "true"
+        ? await enableDependabotFixes(owner, repo, client)
         : null;
 
       // Kick off the process for enabling Secret Scanning

--- a/types/common/index.d.ts
+++ b/types/common/index.d.ts
@@ -17,6 +17,7 @@ export type config = {
 
 export type usersWriteAdminRepos = {
   enableDependabot: boolean;
+  enableDependabotFixes: boolean;
   enableSecretScanning: boolean;
   enableCodeScanning: boolean;
   createIssue: boolean;

--- a/types/common/index.d.ts
+++ b/types/common/index.d.ts
@@ -17,7 +17,7 @@ export type config = {
 
 export type usersWriteAdminRepos = {
   enableDependabot: boolean;
-  enableDependabotFixes: boolean;
+  enableDependabotUpdates: boolean;
   enableSecretScanning: boolean;
   enableCodeScanning: boolean;
   createIssue: boolean;


### PR DESCRIPTION
Closes #42 

Currently, this tooling can only enable Dependabot Alerts but not Dependabot Security Updates.

Introducing new switch for `dependabotupdates` for Dependabot Security Updates. 

I decided to leave the switch for `dependabot` as-is as to not introduce breaking changes. 

BTW: There is only an API for [enabling/disabling security updates](https://docs.github.com/en/rest/reference/repos#enable-automated-security-fixes) (fixes), but not for getting the current status, so we can't check the current status before we enable/disable. 