### PR TITLE
Ft/regex repos w/dry run

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -36,3 +36,11 @@ DEBUG=ghas:*
 # GHES Configuration
 GHES=false
 GHES_SERVER_BASE_URL=
+
+# Dry run
+DRY_RUN=false
+
+# Repo regex. First enable use of regex, and then use one or both of the regex parameters. You can include repos in the run or exclude them.
+REPO_ENABLE_REGEX=false
+REPO_INCLUDE_REGEX=.*
+REPO_EXCLUDE_REGEX=.*

--- a/src/utils/clients/auth.ts
+++ b/src/utils/clients/auth.ts
@@ -9,7 +9,7 @@ export const auth = async (): Promise<string | Error> => {
   }
   /* Checking if they have supplied all the required informaiton to generate a GitHub App */
   if (
-    !env.GITHUB_APP_ID ||
+    !env.APP_ID ||
     !env.APP_PRIVATE_KEY ||
     !env.APP_INSTALLATION_ID ||
     !env.APP_CLIENT_ID ||
@@ -22,12 +22,9 @@ export const auth = async (): Promise<string | Error> => {
 
   /* If there is no hardcoded PAT, but all the required parameters for a GitHub App is provided, generate a token from a GitHub App */
   const options = {
-    appId: env.GITHUB_APP_ID as string,
+    appId: env.APP_ID as string,
     privateKey: env.APP_PRIVATE_KEY as string,
-    appInstallationId: parseInt(
-      env.APP_INSTALLATION_ID as string,
-      10
-    ) as number,
+    installationId: parseInt(env.APP_INSTALLATION_ID as string, 10) as number,
     clientId: env.APP_CLIENT_ID as string,
     clientSecret: env.APP_CLIENT_SECRET as string,
   } as StrategyOptions;

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -95,7 +95,14 @@ export const macCommands = (
     },
     {
       command: "git",
-      args: ["clone","--depth","1","--filter=blob:none","--sparse", `${baseURL}/${owner}/${repo}.git`],
+      args: [
+        "clone",
+        "--depth",
+        "1",
+        "--filter=blob:none",
+        "--sparse",
+        `${baseURL}/${owner}/${repo}.git`,
+      ],
       cwd: `/Users/${user}/${destDir}/${tempDIR}`,
     },
     {

--- a/src/utils/globals.ts
+++ b/src/utils/globals.ts
@@ -32,3 +32,7 @@ export const user = process.cwd().split("/")[2] as string;
 export const winUser = process.cwd().split("\\")[2] as string;
 export const reposFileLocation = "./bin/repos.json" as string;
 export const orgsFileLocation = "./bin/organizations.json" as string;
+export const dryRun = process.env.DRY_RUN  === "true" ? true : false;
+export const useRegex = process.env.REPO_ENABLE_REGEX  === "true" ? true : false;
+export const repoIncludeRegex = process.env.REPO_INCLUDE_REGEX || ("" as string);
+export const repoExcludeRegex = process.env.REPO_EXCLUDE_REGEX || ("" as string);

--- a/src/utils/worker.ts
+++ b/src/utils/worker.ts
@@ -14,7 +14,7 @@ import { enableIssueCreation } from "./enableIssueCreation";
 import repos from "../../bin/repos.json";
 
 import { Octokit } from "./octokitTypes";
-import { inform } from "./globals.js";
+import { inform,dryRun,useRegex,repoIncludeRegex,repoExcludeRegex } from "./globals.js";
 
 export const worker = async (): Promise<unknown> => {
   const client = (await octokit()) as Octokit;
@@ -42,6 +42,37 @@ export const worker = async (): Promise<unknown> => {
       } = repos[orgIndex].repos[repoIndex];
 
       const [owner, repo] = repoName.split("/");
+      
+      var matches=true;
+      if (useRegex && repoIncludeRegex != "" ) {
+          var re = new RegExp(repoIncludeRegex,"i");
+          if (repo.match(re)) {
+             matches=true;
+          } else {
+             matches=false;
+          }
+      }
+      if (useRegex && repoExcludeRegex != "" ) {
+          var re = new RegExp(repoExcludeRegex,"i");
+          if (repo.match(re)) {
+             matches=false;
+          } else {
+             matches=true;
+          }
+      }
+      if (matches == false) {
+         inform(
+          `Skipping repo ${repo} due to regex check`
+         );
+         continue;
+      }
+
+      if (dryRun) {
+        inform(
+         `DRY_RUN: Would run on repo ${repo}`
+        );
+        continue;
+      }
 
       // If Code Scanning or Secret Scanning need to be enabled, let's go ahead and enable GHAS first
       enableCodeScanning || enableSecretScanning
@@ -60,26 +91,34 @@ export const worker = async (): Promise<unknown> => {
 
       // Kick off the process for enabling Code Scanning
       if (enableCodeScanning) {
-        const defaultBranch = await findDefulatBranch(owner, repo, client);
-        const defaultBranchSHA = await findDefulatBranchSHA(
-          defaultBranch,
-          owner,
-          repo,
-          client
+        try {
+          const defaultBranch = await findDefulatBranch(owner, repo, client);
+          const defaultBranchSHA = await findDefulatBranchSHA(
+            defaultBranch,
+            owner,
+            repo,
+            client
+          );
+          const ref = await createBranch(defaultBranchSHA, owner, repo, client);
+          await commitFileMac(owner, repo, ref);
+          const pullRequestURL = await createPullRequest(
+            defaultBranch,
+            ref,
+            owner,
+            repo,
+            client
+          );
+          if (createIssue) {
+            await enableIssueCreation(pullRequestURL, owner, repo, client);
+          }
+          await writeToFile(pullRequestURL);
+      } catch (err: unknown) {
+        inform(
+          `Had an error, skipping ${repo}: ${err}`
         );
-        const ref = await createBranch(defaultBranchSHA, owner, repo, client);
-        await commitFileMac(owner, repo, ref);
-        const pullRequestURL = await createPullRequest(
-          defaultBranch,
-          ref,
-          owner,
-          repo,
-          client
-        );
-        if (createIssue) {
-          await enableIssueCreation(pullRequestURL, owner, repo, client);
-        }
-        await writeToFile(pullRequestURL);
+        continue;
+      }
+
       }
     }
   }


### PR DESCRIPTION
- 
Adds REPO_ENABLE_REGEX to turn on regex filtering and then two options REPO_INCLUDE_REGEX to include maching repos and REPO_EXCLUDE_REGEX to exclude matching repos.

- 
Also added a dry run option in .env, called DRY_RUN for the worker during enable operation. It's pretty basic, but allows me to check what would happen in a run. This is useful for regex testing without actually running anything.  Maybe confusing for others, if they think dry_run applies to everything. It just applies to the npm run start (enable) worker.

- 
Lastly, put a try/catch block in the worker to skip over errors. I have repos that are archived and they get an error since they can't take changes. I also run on existing repos that already have an action on them, so this skips them in a non-ideal way, but allows me to keep going on the full run without getting caught up in a single error on one repo.

Sorry for the comment on the commit, I didn't realize I didn't add one until after. So the changes only say generic reason.