### PR TITLE
Adding refresh to GH APP token

### DIFF
--- a/src/utils/clients/auth.ts
+++ b/src/utils/clients/auth.ts
@@ -32,7 +32,7 @@ export const auth = async (): Promise<string | Error> => {
   const auth = createAppAuth(options);
 
   try {
-    const { token } = await auth({ type: "installation" });
+    const { token } = await auth({ type: "installation", refresh: true });
     return token;
   } catch (err: any) {
     console.error("Error within function (githubAuth)", err.message);


### PR DESCRIPTION
@NickLiffen 

Would this be all that is required to keep the token refreshed each time auth is used?

It looks like that for each repo it loops through, it acquires token.  With the default refresh set to 'false' for [octokit](https://github.com/octokit/auth-app.js/tree/9537cb4ef84870aac702e6ed675a2afce9ebd9be#installation-authentication), it is getting the original token each time.  With this update, I assume it will get a new token each time.