### PR TITLE
Update repos.json structure in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,18 +126,24 @@ This script only returns repositories where CodeQL results have not already been
 
 **OPTION 3**
 
-Create a file called `repos.json` within the `./bin/` directory. This file needs to have an array of objects. The structure of the objects should look like this:
+Create a file called `repos.json` within the `./bin/` directory. This file needs to have an array of organization objects, each with its own array of repository objects. The structure of the objects should look like this:
 
 ```JSON
 [
   {
-    "enableDependabot": "boolean",
-    "enableDependabotUpdates": "boolean",
-    "enableSecretScanning": "boolean",
-    "enableCodeScanning": "boolean",
-    "createIssue": "boolean",
-    "enablePushProtection": "boolean",
-    "repo": "string <org/repo>",
+    "login": "string <org>",
+    "repos":
+    [
+      {
+        "enableDependabot": "boolean",
+        "enableDependabotUpdates": "boolean",
+        "enableSecretScanning": "boolean",
+        "enableCodeScanning": "boolean",
+        "createIssue": "boolean",
+        "enablePushProtection": "boolean",
+        "repo": "string <org/repo>",
+      }
+    ]
   }
 ]
 ```


### PR DESCRIPTION
The `README.md` has out of date information for the structure of the `repos.json` file. This change clarifies that the file requires two arrays - an outer organizations array and an inner repositories array.