### PR TITLE
Fix analysis check

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git clone https://github.com/NickLiffen/ghas-enablement.git
 cd ghas-enablement
 ```
 
-3.  Generate your choosen authentication stratergy. You are either able to use a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps) or a [Personal Access Token (PAT)](https://github.com/settings/tokens/new). The GitHub App needs to have permissions of `read and write` of `pull requests`, `issues`, `administration`, `contents`. The GitHub PAT needs access to `repo` and `read:org` only. (if you are running `yarn run getOrgs` you will also need the `read:enterprise` scope).
+3.  Generate your choosen authentication stratergy. You are either able to use a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps) or a [Personal Access Token (PAT)](https://github.com/settings/tokens/new). The GitHub App needs to have permissions of `read and write` of `pull requests`, `issues`, `administration`, `contents`, `workflows`. The GitHub PAT needs access to `repo` and `read:org` only. (if you are running `yarn run getOrgs` you will also need the `read:enterprise` scope).
 
 4.  Rename the `.env.sample` to `.env`. On a Mac, this can be done via the following terminal command:
 
@@ -84,7 +84,7 @@ cp .env.sample .env
 
 7. Update the `LANGUAGE_TO_CHECK` value found within the `.env`. Remove the `XXXX` and replace that with the language you would like to use as a filter when collecting repositories. **Note**: Please make sure these are lowercase values, such as: `javascript`, `python`, `go`, `ruby`, etc.
 
-8. Decide what you want to enable. Update the `ENABLE_ON` value to choose what you want to enable on the repositories found within the `repos.json`. This can be one or multiple values. If you are enabling just code scanning (CodeQL) you will need to set `ENABLE_ON=codescanning`, if you are enabling everything, you will need to set `ENABLE_ON=codescanning,secretscanning,dependabot,dependabotupdates`. You can pick one, two or three. The format is a comma seperated list.
+8. Decide what you want to enable. Update the `ENABLE_ON` value to choose what you want to enable on the repositories found within the `repos.json`. This can be one or multiple values. If you are enabling just code scanning (CodeQL) you will need to set `ENABLE_ON=codescanning`, if you are enabling everything, you will need to set `ENABLE_ON=codescanning,secretscanning,pushprotection,dependabot,dependabotupdates`. You can pick one, two or three. The format is a comma seperated list.
 
 9. **OPTIONAL**: Update the `CREATE_ISSUE` value to `true/false` depending on if you would like to create an issue explaining purpose of the PR. We recommend this, as it will help explain why the PR was create; and give some context. However, this is optional. The text which is in the issue can be modified and found here: `./src/utils/text/`.
 
@@ -202,7 +202,7 @@ env:
   APP_CLIENT_ID: ${{ secrets.GHAS_ENABLEMENT_APP_CLIENT_ID }}
   APP_CLIENT_SECRET: ${{ secrets.GHAS_ENABLEMENT_APP_CLIENT_SECRET }}
   APP_PRIVATE_KEY: ${{ secrets.GHAS_ENABLEMENT_APP_PRIVATE_KEY }}
-  ENABLE_ON: "codescanning,secretscanning,dependabot,dependabotupdates"
+  ENABLE_ON: "codescanning,secretscanning,pushprotection,dependabot,dependabotupdates"
   DEBUG: "ghas:*"
   CREATE_ISSUE: "false"
   GHES: "false"
@@ -228,6 +228,7 @@ jobs:
           npm run start
         env:
           LANGUAGE_TO_CHECK: "javascript"
+          TEMP_DIR: ${{ github.workspace }}
 ```
 
 You can duplicate the last step for the other languages commonly used within your enterprise/organisation.

--- a/src/utils/checkCodeQLEnablement.ts
+++ b/src/utils/checkCodeQLEnablement.ts
@@ -21,8 +21,9 @@ export const checkIfCodeQLHasAlreadyRanOnRepo = async (
       "GET /repos/{owner}/{repo}/code-scanning/analyses",
       requestParams
     )) as checkCodeScanningAnalysesResponse;
-    if (data.length === 0) return false;
-    return true;
+    // If there are no analysis, the result is not a list and data.length will return undefined.
+    if (data.length > 0) return true;
+    return false;
   } catch (e) {
     if (e instanceof RequestError) {
       if (e.status == 404) return false; // 404 result means no codeQL scans found


### PR DESCRIPTION
Hello @NickLiffen 

We finally got our GitHub Advanced Security licenses so we are going to start rolling out code-scanning to all repos 🎉 .
I wanted to do some final tests and noticed a bug however. 

When you introduced the functionality to no longer create pull-requests for repos that already have `code-scanning/analyses` I did a quick test to see if it didn't create a pr anymore on a repo that was already scanned and that worked.
Today  I tested on some new repo's and I found that a pr was actually never created.

I noticed that when there is no analysis available yet the GitHub Api returns
```
{
  "message": "no analysis found",
  "documentation_url": "https://docs.github.com/rest/reference/code-scanning#list-code-scanning-analyses-for-a-repository"
}
```
instead of an empty list, so `data.length` in this case results in `undefined`. Perhaps this is something that changed over time.
I only changed the condition a bit and now it seems to work (again). 

Also I believe that GitHub changed something to the security model because I had to update my app permissions:

> 2022-07-12T13:18:49.100Z ghas:error Error: Command failed: git push --set-upstream origin ghas-BEfYw
To https://github.com/liantisit-github-automation-poc/azure-functions-medewerkerspaspoort-poc.git
 ! [remote rejected] ghas-BEfYw -> ghas-BEfYw (refusing to allow a GitHub App to create or update workflow `.github/workflows/codeql-analysis.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/liantisit-github-automation-poc/azure-functions-medewerkerspaspoort-poc.git'

I updated the doc accordingly.  

Kind regards,
Jors