### PR TITLE
move @octokit/plugin-retry to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "Advanced Security"
   ],
   "devDependencies": {
+    "@octokit/plugin-retry": "^4.1.2",
     "@tsconfig/node18": "^1.0.1",
     "@types/aws-lambda": "^8.10.111",
     "@types/debug": "^4.1.7",
@@ -52,7 +53,6 @@
     "@octokit/auth-app": "^4.0.9",
     "@octokit/core": "^4.2.0",
     "@octokit/plugin-paginate-rest": "^6.0.0",
-    "@octokit/plugin-retry": "^4.1.2",
     "@octokit/plugin-throttling": "^5.0.1",
     "@octokit/request-error": "^3.0.3",
     "@octokit/types": "^9.0.0",


### PR DESCRIPTION
Not sure if it was just me having this problem, but I had this problem both locally and in a Codespace.

```bash
node -v && npm -v

v18.11.0
8.19.2
```

When running a fresh clone and setup:

```bash
npm install
npm run build

src/utils/clients/core.ts:9:23 - error TS7016: Could not find a declaration file for module '@octokit/plugin-retry'. '/Users/joshjohanning/Repos/ghas-enablement-clean/node_modules/@octokit/plugin-retry/dist-node/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/octokit__plugin-retry` if it exists or add a new declaration (.d.ts) file containing `declare module '@octokit/plugin-retry';`

9 import { retry } from "@octokit/plugin-retry";
                        ~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/utils/clients/core.ts:9

```

When running this which adds this as to `devDependencies` instead, it works:

```
npm i --save-dev @octokit/plugin-retry
```

Builds:

```
npm run build

> github-helper@1.0.0 build
> npx tsc
```