### PR TITLE
c++/c# workflow file bug, kotlin/typescript support, and readme updates

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@ GITHUB_API_TOKEN=
 GITHUB_ENTERPRISE=
 GITHUB_ORG=
 
-# If you are filtering by language, set the language here. Please use either: javascript, go, python, ruby, java
+# If you are filtering by language, set the language here. Please use either: javascript, go, python, ruby, java, c#, c++
 LANGUAGE_TO_CHECK=
 
 # Specify what to enable. The default will be codescanning. An example is: E.G ENABLE_ON=codescanning,secretscanning,dependabot,dependabotupdates,pushprotection

--- a/.env.sample
+++ b/.env.sample
@@ -21,10 +21,10 @@ GITHUB_API_TOKEN=
 GITHUB_ENTERPRISE=
 GITHUB_ORG=
 
-# If you are filtering by language, set the language here. Please use either: javascript, go, python, ruby, java, c#, c++
+# If you are filtering by language, set the language here. Please use either: javascript, typescript, go, python, ruby, c#, c++, java, or kotlin
 LANGUAGE_TO_CHECK=
 
-# Specify what to enable. The default will be codescanning. An example is: E.G ENABLE_ON=codescanning,secretscanning,dependabot,dependabotupdates,pushprotection
+# Specify what to enable. The default will be codescanning. An example is: ENABLE_ON=codescanning,secretscanning,dependabot,dependabotupdates,pushprotection,actions
 ENABLE_ON=secretscanning
 
 # Create Issue on Repository

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ If you select option 1, the script will return all repositories in the language 
 Loops over the repositories found within the `repos.json` file and enables Code Scanning(CodeQL)/Secret Scanning/Secret Scanning Push Protection/Dependabot Alerts/Dependabot Security Updates.
 
 - If you pick Code Scanning:
-  - Loops over the repositories found within the `repos.json` file. A pull request gets created on that repository with the `codeql-analysis-${language}.yml` found in the `bin/workflows` directory. 
-  - The `${language}` will be replaced at runtime with the primary language of the repository. 
+  - Loops over the repositories found within the `repos.json` file. A pull request gets created on that repository with the `codeql-analysis-${language}.yml` found in the `bin/workflows` directory.
+  - The `${language}` will be replaced at runtime with the primary language of the repository.
   - For convenience, all pull requests made will be stored within the `prs.txt` file, where you can see and manually review the pull requests after the script has run.
 - If you pick Secret Scanning:
   - Loops over the repositories found within the `repos.json` file. Secret Scanning is then enabled on these repositories.
@@ -40,7 +40,7 @@ Loops over the repositories found within the `repos.json` file and enables Code 
 - If you pick Dependabot Security Updates:
   - Loops over the repositories found within the `repos.json` file. Dependabot Security Updates is then enabled on these repositories.
 - If you pick Actions:
-  - Loops over the repositories found within the `repos.json` file. Actions is then enabled on these repositories. 
+  - Loops over the repositories found within the `repos.json` file. Actions is then enabled on these repositories.
   - This is useful if you want to ensure that the Code Scanning workflow can run and Actions isn't disabled.
 - If you pick Create Issue:
   - Loops over the repositories found within the `repos.json` file. An issue will be created with the [following text](./src/utils/text/issueText.ts).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are two main actions this tool does:
 
 **Part One:**
 
-Goes and collects repositories that will have Code Scanning (CodeQL)/Secret Scanning/Secret Scanning Push Protection/Dependabot Alerts/Dependabot Security Updates enabled. There are three main ways these repositories are collected.
+Goes and collects repositories that will have Code Scanning (CodeQL)/Secret Scanning/Secret Scanning Push Protection/Dependabot Alerts/Dependabot Security Updates/Actions enabled. There are three main ways these repositories are collected.
 
 - Collect the repositories where the primary language matches a specific value. For example, if you provide JavaScript, all repositories will be collected where the primary language is, Javascript.
 - Collect the repositories to which a user has administrative access, or a GitHub App has access.
@@ -125,7 +125,7 @@ This script only returns repositories where CodeQL results have not already been
 yarn run getRepos # or npm run getRepos
 ```
 
-Similar to step one, another automated approach is to enable by user access (i.e., enable for all repositories the PAT has access to). This approach will be a little less accurate as the `codeql-analysis.yml` file will most certainly need changing between a Python project and a Java project (if you are enabling CodeQL). But the file you propose is going to be a good start. After running the command, you are welcome to modify the `./bin/repos.json` file. Just make sure it's a valid JSON file before saving.
+Similar to step one, another automated approach is to enable by user access (i.e., enable for all repositories the user/PAT has administrative access to). This approach will be a little less accurate as the `codeql-analysis.yml` file will most certainly need changing between a Python project and a Java project (if you are enabling CodeQL). But the file you propose is going to be a good start. After running the command, you are welcome to modify the `./bin/repos.json` file. Just make sure it's a valid JSON file before saving.
 
 This script only returns repositories where CodeQL results have not already been uploaded to code scanning. If any CodeQL results have been uploaded to a repositories code scanning feature, that repository will not be returned to this list. The motivation behind this is not to raise pull requests on repositories where CodeQL has already been enabled.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Loops over the repositories found within the `repos.json` file and enables Code 
 
 6.  Update the `GITHUB_ORG` value found within the `.env`. Remove the `XXXX` and replace that with the name of the GitHub Organisation you would like to use as part of this script. **NOTE**: If you are running this across multiple organisations within an enterprise, you can not set the `GITHUB_ORG` variable and instead set the `GITHUB_ENTERPRISE` one with the name of the enterprise. You can then run `yarn run getOrgs`, which will collect all the organisations dynamically. This will mean you don't have to hardcode one. However, for most use cases, simply hardcoding the specific org within the `GITHUB_ORG` variable where you would like this script to run will work.
 
-7.  Update the `LANGUAGE_TO_CHECK` value found within the `.env`. Remove the `XXXX` and replace that with the language you would like to use as a filter when collecting repositories. **Note**: Please make sure these are lowercase values, such as: `javascript`, `python`, `go`, `ruby`, `c#`, `c++`, etc.
+7.  Update the `LANGUAGE_TO_CHECK` value found within the `.env`. Remove the `XXXX` and replace that with the language you would like to use as a filter when collecting repositories. **Note**: Please make sure these are lowercase values, such as: `javascript`, `typescript`, `python`, `go`, `ruby`, `c#`, `c++`, `java`, or `kotlin`
 
 8.  Decide what you want to enable. Update the `ENABLE_ON` value to choose what you want to enable on the repositories found within the `repos.json`. This can be one or multiple values. If you are enabling just code scanning (CodeQL) you will need to set `ENABLE_ON=codescanning`, if you are enabling everything, you will need to set `ENABLE_ON=codescanning,secretscanning,pushprotection,dependabot,dependabotupdates,actions`. You can pick one, two or three. The format is a comma-seperated list.
 
@@ -110,20 +110,22 @@ The first step is collecting the repositories you would like to run this script 
 **OPTION 1** (Preferred)
 
 ```bash
-yarn run getRepos // In the `.env` set the `LANGUAGE_TO_CHECK=` to the language. E.G `python`, `javascript`, `go`, `ruby`, `c#`, `c++`, etc.
+# In the `.env` set the `LANGUAGE_TO_CHECK=` to the language. E.G.: `javascript`, `typescript`, `python`, `go`, `ruby`, `c#`, `c++`, `java`, or `kotlin`
+yarn run getRepos # or npm run getRepos
 ```
 
-When using GitHub Actions, we commonly find (especially for non-build languages such as JavaScript) that the `codeql-analysis.yml` file is repeatable and consistent across multiple repositories of the same language. About 80% of the time, teams can reuse the same workflow files for the same language. For Java, C++ that number drops down to about 60% of the time. But the reason why we recommend enabling Code Scanning at bulk via language is the `codeql-analysis.yml` file you propose within the pull request has the highest chance of being most accurate. Even if the file needs changing, the team reviewing the pull request would likely only need to make small changes. We recommend you run this command first to get a list of repositories to enable Code Scanning. After running the command, you are welcome to modify this file. Just make sure it's a valid JSON file if you do edit.
+When using GitHub Actions, we commonly find (especially for non-build languages such as JavaScript) that the `codeql-analysis.yml` file is repeatable and consistent across multiple repositories of the same language. About 80% of the time, teams can reuse the same workflow files for the same language. For Java, C++ that number drops down to about 60% of the time. But the reason why we recommend enabling Code Scanning at bulk via language is the `codeql-analysis.yml` file you propose within the pull request has the highest chance of being most accurate. Even if the file needs changing, the team reviewing the pull request would likely only need to make small changes. We recommend you run this command first to get a list of repositories to enable Code Scanning. After running the command, you are welcome to modify the `./bin/repos.json` file. Just make sure it's a valid JSON file before saving.
 
 This script only returns repositories where CodeQL results have not already been uploaded to code scanning. If any CodeQL results have been uploaded to a repositories code scanning feature, that repository will not be returned to this list. The motivation behind this is not to raise pull requests on repositories where CodeQL has already been enabled.
 
 **OPTION 2**
 
 ```bash
-yarn run getRepos // or npm run getRepos
+# In the `.env` leave the `LANGUAGE_TO_CHECK=` empty to pull in all repos
+yarn run getRepos # or npm run getRepos
 ```
 
-Similar to step one, another automated approach is to enable by user access. This approach will be a little less accurate as the file will most certainly need changing between a Python project and a Java project (if you are enabling CodeQL), and the user's PAT you are using will most likely. But the file you propose is going to be a good start. After running the command, you are welcome to modify this file. Just make sure it's a valid JSON file if you do edit.
+Similar to step one, another automated approach is to enable by user access (i.e., enable for all repositories the PAT has access to). This approach will be a little less accurate as the `codeql-analysis.yml` file will most certainly need changing between a Python project and a Java project (if you are enabling CodeQL). But the file you propose is going to be a good start. After running the command, you are welcome to modify the `./bin/repos.json` file. Just make sure it's a valid JSON file before saving.
 
 This script only returns repositories where CodeQL results have not already been uploaded to code scanning. If any CodeQL results have been uploaded to a repositories code scanning feature, that repository will not be returned to this list. The motivation behind this is not to raise pull requests on repositories where CodeQL has already been enabled.
 

--- a/README.md
+++ b/README.md
@@ -27,33 +27,24 @@ If you select option 1, the script will return all repositories in the language 
 
 Loops over the repositories found within the `repos.json` file and enables Code Scanning(CodeQL)/Secret Scanning/Secret Scanning Push Protection/Dependabot Alerts/Dependabot Security Updates.
 
-If you pick Code Scanning:
-
-- Loops over the repositories found within the `repos.json` file. A pull request gets created on that repository with the `codeql-analysis-${language}.yml` found in the `bin/workflows` directory. The `${language}` will be replaced at runtime with the primary language of the repository. For convenience, all pull requests made will be stored within the `prs.txt` file, where you can see and manually review the pull requests after the script has run.
-
-If you pick Secret Scanning:
-
-- Loops over the repositories found within the `repos.json` file. Secret Scanning is then enabled on these repositories.
-
-If you pick Push Protections:
-
-- Loops over the repositories found within the `repos.json` file. Secret Scanning Push Protection is then enabled on these repositories.
-
-If you pick Dependabot Alerts:
-
-- Loops over the repositories found within the `repos.json` file. Dependabot Alerts is then enabled on these repositories.
-
-If you pick Dependabot Security Updates:
-
-- Loops over the repositories found within the `repos.json` file. Dependabot Security Updates is then enabled on these repositories.
-
-If you pick Actions:
-
-- Loops over the repositories found within the `repos.json` file. Actions is then enabled on these repositories. This is useful if you want to ensure that the Code Scanning workflow can run and Actions isn't disabled.
-
-If you pick Create Issue:
-
-- Loops over the repositories found within the `repos.json` file. An issue will be created with the [following text](./src/utils/text/issueText.ts) alerting repository maintainers that a pull request for CodeQL was created, along with other helpful resources.
+- If you pick Code Scanning:
+  - Loops over the repositories found within the `repos.json` file. A pull request gets created on that repository with the `codeql-analysis-${language}.yml` found in the `bin/workflows` directory. 
+  - The `${language}` will be replaced at runtime with the primary language of the repository. 
+  - For convenience, all pull requests made will be stored within the `prs.txt` file, where you can see and manually review the pull requests after the script has run.
+- If you pick Secret Scanning:
+  - Loops over the repositories found within the `repos.json` file. Secret Scanning is then enabled on these repositories.
+- If you pick Push Protections:
+  - Loops over the repositories found within the `repos.json` file. Secret Scanning Push Protection is then enabled on these repositories.
+- If you pick Dependabot Alerts:
+  - Loops over the repositories found within the `repos.json` file. Dependabot Alerts is then enabled on these repositories.
+- If you pick Dependabot Security Updates:
+  - Loops over the repositories found within the `repos.json` file. Dependabot Security Updates is then enabled on these repositories.
+- If you pick Actions:
+  - Loops over the repositories found within the `repos.json` file. Actions is then enabled on these repositories. 
+  - This is useful if you want to ensure that the Code Scanning workflow can run and Actions isn't disabled.
+- If you pick Create Issue:
+  - Loops over the repositories found within the `repos.json` file. An issue will be created with the [following text](./src/utils/text/issueText.ts).
+  - This alerts repository maintainers that a pull request for CodeQL was created, along with other helpful resources.
 
 ## Prerequisites
 
@@ -94,7 +85,7 @@ If you pick Create Issue:
 
 6.  Update the `GITHUB_ORG` value found within the `.env`. Remove the `XXXX` and replace that with the name of the GitHub Organisation you would like to use as part of this script. **NOTE**: If you are running this across multiple organisations within an enterprise, you can not set the `GITHUB_ORG` variable and instead set the `GITHUB_ENTERPRISE` one with the name of the enterprise. You can then run `yarn run getOrgs`, which will collect all the organisations dynamically. This will mean you don't have to hardcode one. However, for most use cases, simply hardcoding the specific org within the `GITHUB_ORG` variable where you would like this script to run will work.
 
-7.  Update the `LANGUAGE_TO_CHECK` value found within the `.env`. Remove the `XXXX` and replace that with the language you would like to use as a filter when collecting repositories. **Note**: Please make sure these are lowercase values, such as: `javascript`, `python`, `go`, `ruby`, `c#`, etc.
+7.  Update the `LANGUAGE_TO_CHECK` value found within the `.env`. Remove the `XXXX` and replace that with the language you would like to use as a filter when collecting repositories. **Note**: Please make sure these are lowercase values, such as: `javascript`, `python`, `go`, `ruby`, `c#`, `c++`, etc.
 
 8.  Decide what you want to enable. Update the `ENABLE_ON` value to choose what you want to enable on the repositories found within the `repos.json`. This can be one or multiple values. If you are enabling just code scanning (CodeQL) you will need to set `ENABLE_ON=codescanning`, if you are enabling everything, you will need to set `ENABLE_ON=codescanning,secretscanning,pushprotection,dependabot,dependabotupdates,actions`. You can pick one, two or three. The format is a comma-seperated list.
 
@@ -119,7 +110,7 @@ The first step is collecting the repositories you would like to run this script 
 **OPTION 1** (Preferred)
 
 ```bash
-yarn run getRepos // In the `.env` set the `LANGUAGE_TO_CHECK=` to the language. E.G `python`, `javascript`, `go`, `ruby`, `c#`, etc.
+yarn run getRepos // In the `.env` set the `LANGUAGE_TO_CHECK=` to the language. E.G `python`, `javascript`, `go`, `ruby`, `c#`, `c++`, etc.
 ```
 
 When using GitHub Actions, we commonly find (especially for non-build languages such as JavaScript) that the `codeql-analysis.yml` file is repeatable and consistent across multiple repositories of the same language. About 80% of the time, teams can reuse the same workflow files for the same language. For Java, C++ that number drops down to about 60% of the time. But the reason why we recommend enabling Code Scanning at bulk via language is the `codeql-analysis.yml` file you propose within the pull request has the highest chance of being most accurate. Even if the file needs changing, the team reviewing the pull request would likely only need to make small changes. We recommend you run this command first to get a list of repositories to enable Code Scanning. After running the command, you are welcome to modify this file. Just make sure it's a valid JSON file if you do edit.

--- a/bin/workflows/codeql-analysis-cpp.yml
+++ b/bin/workflows/codeql-analysis-cpp.yml
@@ -34,6 +34,8 @@ jobs:
       matrix:
         language: ["cpp"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/bin/workflows/codeql-analysis-csharp.yml
+++ b/bin/workflows/codeql-analysis-csharp.yml
@@ -34,6 +34,8 @@ jobs:
       matrix:
         language: ["csharp"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/bin/workflows/codeql-analysis-go.yml
+++ b/bin/workflows/codeql-analysis-go.yml
@@ -34,6 +34,8 @@ jobs:
       matrix:
         language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/bin/workflows/codeql-analysis-java.yml
+++ b/bin/workflows/codeql-analysis-java.yml
@@ -34,6 +34,8 @@ jobs:
       matrix:
         language: ["java"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/bin/workflows/codeql-analysis-javascript.yml
+++ b/bin/workflows/codeql-analysis-javascript.yml
@@ -34,6 +34,8 @@ jobs:
       matrix:
         language: ["javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/bin/workflows/codeql-analysis-python.yml
+++ b/bin/workflows/codeql-analysis-python.yml
@@ -34,6 +34,8 @@ jobs:
       matrix:
         language: ["python"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/bin/workflows/codeql-analysis-ruby.yml
+++ b/bin/workflows/codeql-analysis-ruby.yml
@@ -34,6 +34,8 @@ jobs:
       matrix:
         language: ["ruby"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Use only 'java' to analyze code written in Java, Kotlin or both
+        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:

--- a/src/utils/commitFile.ts
+++ b/src/utils/commitFile.ts
@@ -11,6 +11,8 @@ import { execFile as ImportedExec } from "child_process";
 
 import { response, commands } from "../../types/common";
 
+import { getcodeQLLanguage } from "./getcodeQLLanguage";
+
 const execFile = util.promisify(ImportedExec);
 
 inform(`Platform detected: ${platform}`);
@@ -44,7 +46,7 @@ export const commitFileMac = async (
   const {
     env: { LANGUAGE_TO_CHECK: language },
   } = process;
-  let codeQLLanguage = language;
+  let codeQLLanguage = getcodeQLLanguage(language || "");
   if (!codeQLLanguage && primaryLanguage != "no-language") {
     codeQLLanguage = primaryLanguage;
   }

--- a/src/utils/getcodeQLLanguage.ts
+++ b/src/utils/getcodeQLLanguage.ts
@@ -11,8 +11,14 @@ export const getcodeQLLanguage = (primaryLanguage: string): string => {
     case "javascript":
       codeQLLang = "javascript";
       break;
+    case "typescript":
+      codeQLLang = "javascript"; // use javascript for typescript
+      break;
     case "java":
       codeQLLang = "java";
+      break;
+    case "kotlin":
+      codeQLLang = "java"; // use java for kotlin
       break;
     case "go":
       codeQLLang = "go";


### PR DESCRIPTION
## c++ / c# bug

In the `.env` file, you need to specify `c#` or `c++` in order to find these languages.

In the `repos.json` file, we translate it to `csharp` or `cpp` I believe here:
https://github.com/NickLiffen/ghas-enablement/blob/main/src/utils/paginateQuery.ts#L108

Then when we go to create a pull request with the appropriate CodeQL yml file, it was previously still using `c#` or `c++`:

> ghas:error Error: Command failed: cp ./bin/workflows/codeql-analysis-c#.yml /Users/joshjohanning/Desktop/tempGitLocations/Wolfringo-github-packages/.github/workflows/codeql-analysis.yml
> ghas:error cp: ./bin/workflows/codeql-analysis-c#.yml: No such file or directory

Now, with this commit (https://github.com/NickLiffen/ghas-enablement/commit/ef96a506e2d838b67c362a65ae14a80ba215df1a), we still use `c#` and `c++` in the `.env` file like before, but now it looks to use `csharp` and `cpp` yml files accordingly.

resolves: #108 ?

## kotlin/typescript support

adding `kotlin` and `typescript` to the `./src/utils/getcodeQLLanguage.ts` [file](https://github.com/NickLiffen/ghas-enablement/blob/main/src/utils/getcodeQLLanguage.ts).

```diff
+      case "typescript":
+      codeQLLang = "javascript"; // use javascript for typescript
+      break;
...
+      case "kotlin":
+      codeQLLang = "java"; // use java for kotlin
+      break;
```

## readme edits

- Adding example to clarify usage in `.env` file for `c++` and `c#` (use `c#` not `csharp` here, for example)
  - added this to readme and `.env.sample` file
- adding additional items to the `Part Two` section
- using bullet points for the `Part Two` section for easier reading
- hyperlink to where you can update the issue text
- updating actions example to use `actions/checkout@v3`(from `v2`)
- adding `enableActions` to actions example
- adding `enableActions` to example `repos.json` syntax in readme
- adding in `kotlin` and `typescript` to the list of languages in readme and `.env.sample`