### PR TITLE
Improve createFile function to include file location in success message

### DIFF
--- a/src/utils/writeToFile.ts
+++ b/src/utils/writeToFile.ts
@@ -30,8 +30,8 @@ export const createFile = async (
     const writeFile = promisify(fs.writeFile);
     const data = JSON.stringify(list, null, 2);
     writeFile(fileLocation, data);
-    inform(`Success created repos.json`);
-    return { status: 200, message: "Success created repos.json" };
+    inform(`Success created ${fileLocation}`);
+    return { status: 200, message: `Success created ${fileLocation}` };
   } catch (err) {
     error(err);
     throw err;


### PR DESCRIPTION
Otherwise in the case where `getOrgs` was executed, the output reads `"Success created repos.json"`. Unexpectedly suggesting that repositories were fetched.